### PR TITLE
fix: conflict between clauses on datefilter

### DIFF
--- a/src/Filters/DateFilter.php
+++ b/src/Filters/DateFilter.php
@@ -35,11 +35,12 @@ class DateFilter extends Filter
                 if ($state['clause'] === self::CLAUSE_SET || $state['clause'] === self::CLAUSE_NOT_SET) {
                     return [$message];
                 }
-                if ($state['value']) {
-                    if ($state['clause'] === self::CLAUSE_GREATER_THAN || $state['clause'] === self::CLAUSE_LESS_THAN) {
-                        return [$message . ' ' . $state['value']. ' ' . $state['period'] . ' ' . $state['direction']];
-                    }
+                if ($state['period_value']
+                    && ($state['clause'] === self::CLAUSE_GREATER_THAN || $state['clause'] === self::CLAUSE_LESS_THAN)) {
+                    return [$message . ' ' . $state['period_value'] . ' ' . $state['period'] . ' ' . $state['direction']];
+                }
 
+                if ($state['value']) {
                     return [$message . ' ' . Carbon::parse($state['value'])->format(config('tables.date_format', 'Y-m-d'))];
                 }
                 if ($state['from'] || $state['until']) {
@@ -85,11 +86,11 @@ class DateFilter extends Filter
             return $query
                 ->when(
                     $data['from'],
-                    fn (Builder $query, $date): Builder => $query->whereDate($column, '>=', $date),
+                    fn(Builder $query, $date): Builder => $query->whereDate($column, '>=', $date),
                 )
                 ->when(
                     $data['until'],
-                    fn (Builder $query, $date): Builder => $query->whereDate($column, '<=', $date),
+                    fn(Builder $query, $date): Builder => $query->whereDate($column, '<=', $date),
                 );
         }
 
@@ -103,22 +104,22 @@ class DateFilter extends Filter
         return $query
             ->when(
                 $isSetClause,
-                fn (Builder $query) => $query->where($column, $operator, null)
+                fn(Builder $query) => $query->where($column, $operator, null)
             )
             ->when(
                 !empty($value) && !$isSetClause,
-                fn (Builder $query) => $query->where($column, $operator, $value)
+                fn(Builder $query) => $query->where($column, $operator, $value)
             );
     }
 
     protected function formatPeriodClause($data): ?Carbon
     {
-        if (empty($data['value'])) {
+        if (empty($data['period_value'])) {
             return null;
         }
 
         return Carbon::parse(implode(' ', [
-            intval($data['value']),
+            intval($data['period_value']),
             $data['period'],
             $data['direction']
         ]));
@@ -128,7 +129,8 @@ class DateFilter extends Filter
     {
         return [
             DatePicker::make('value')
-                ->when(fn ($get) => !in_array($get('clause'), [
+                ->disableLabel()
+                ->when(fn($get) => !in_array($get('clause'), [
                     static::CLAUSE_GREATER_THAN,
                     static::CLAUSE_LESS_THAN,
                     static::CLAUSE_BETWEEN,
@@ -137,15 +139,15 @@ class DateFilter extends Filter
                     null
                 ])),
             DatePicker::make('from')
-                ->when(fn ($get) => $get('clause') == static::CLAUSE_BETWEEN),
+                ->when(fn($get) => $get('clause') == static::CLAUSE_BETWEEN),
             DatePicker::make('until')
-                ->when(fn ($get) => $get('clause') == static::CLAUSE_BETWEEN),
-            TextInput::make('value')
+                ->when(fn($get) => $get('clause') == static::CLAUSE_BETWEEN),
+            TextInput::make('period_value')
                 ->type('number')
                 ->minValue(0)
                 ->disableLabel()
                 ->placeholder('0')
-                ->when(fn ($get) => in_array($get('clause'), [
+                ->when(fn($get) => in_array($get('clause'), [
                     static::CLAUSE_GREATER_THAN,
                     static::CLAUSE_LESS_THAN,
                 ])),
@@ -159,7 +161,7 @@ class DateFilter extends Filter
                 ->disableLabel()
                 ->default('days')
                 ->disablePlaceholderSelection()
-                ->when(fn ($get) => in_array($get('clause'), [
+                ->when(fn($get) => in_array($get('clause'), [
                     static::CLAUSE_GREATER_THAN,
                     static::CLAUSE_LESS_THAN,
                 ])),
@@ -170,7 +172,7 @@ class DateFilter extends Filter
                 ])
                 ->disableLabel()
                 ->disablePlaceholderSelection()
-                ->when(fn ($get) => in_array($get('clause'), [
+                ->when(fn($get) => in_array($get('clause'), [
                     static::CLAUSE_GREATER_THAN,
                     static::CLAUSE_LESS_THAN,
                 ])),


### PR DESCRIPTION
Fix conflict between clauses

- less/greater than
- is equal/not equal to
- is on or after/before