### PR TITLE
Add > character

### DIFF
--- a/src/Filters/DateFilter.php
+++ b/src/Filters/DateFilter.php
@@ -145,7 +145,7 @@ class DateFilter extends Filter
                 ->label(__('filament-advancedfilter::clauses.from'))
                 ->when(fn ($get) => $get('clause') == static::CLAUSE_BETWEEN),
             DatePicker::make('until')
-                - label(__('filament-advancedfilter::clauses.until'))
+                ->label(__('filament-advancedfilter::clauses.until'))
                 ->when(fn ($get) => $get('clause') == static::CLAUSE_BETWEEN),
             TextInput::make('period_value')
                 ->type('number')


### PR DESCRIPTION
There is a missing ">" character that needs to be added in here, as otherwise the code tries to invoke a non-existent "label" method of the class instead of the DatePicker "label" method