### PR TITLE
Fix the Indication message on Number Filter for Between

### DIFF
--- a/src/Filters/NumberFilter.php
+++ b/src/Filters/NumberFilter.php
@@ -30,11 +30,11 @@ class NumberFilter extends BaseFilter
                 if ($state['clause'] === self::CLAUSE_SET || $state['clause'] === self::CLAUSE_NOT_SET) {
                     return [$this->getLabel() . ' ' . $this->clauses()[$state['clause']]];
                 }
+                if ($state['clause'] === self::CLAUSE_BETWEEN) {
+                    return [$this->getLabel() . ' ' . $this->clauses()[$state['clause']] . ' ' . ($state['from'] ?? 0) . ' and ' . ($state['until'] ?? "~")];
+                }
                 if ($state['value']) {
                     return [$this->getLabel() . ' ' . $this->clauses()[$state['clause']] . ' ' . $state['value']];
-                }
-                if ($state['from'] || $state['until']) {
-                    return [$this->getLabel() . ' ' . $this->clauses()[$state['clause']] . ' ' . ($state['from'] ?? 0) . ' and ' . ($state['until'] ?? "~")];
                 }
             }
 


### PR DESCRIPTION
The **Number Filter** is showing the **Wrong Indication** when selected the **Between** mode of matching.  
  
![Image Reference](https://storage.googleapis.com/sharing-kingmaker/online-reference/communities/github/filament-advanced-filter/filter-wrong-indication.png)  
  
I have fixed the Issue in the PR. BTW, Thanks for the wonderful package.