### PR TITLE
Error handling if clause and value not found in TextFilter

### DIFF
--- a/src/Filters/TextFilter.php
+++ b/src/Filters/TextFilter.php
@@ -28,10 +28,18 @@ class TextFilter extends BaseFilter
         parent::setUp();
 
         $this->indicateUsing(function (array $state): array {
+            if (!isset($state['clause'])) {
+                return [];
+            }
+            
             if ($state['clause'] === self::CLAUSE_SET || $state['clause'] === self::CLAUSE_NOT_SET) {
                 return [$this->getLabel() . ' ' . $this->clauses()[$state['clause']]];
             }
 
+            if (!isset($state['value'])) {
+                return [];
+            }
+            
             if ($state['clause'] && $state['value']) {
                 return [$this->getLabel() . ' ' . $this->clauses()[$state['clause']] . ' "' . $state['value'] . '"'];
             }


### PR DESCRIPTION
Error handling if clause and value not found in TextFilter. It was applied in other Filters but not on this one.

To prevent errors like these.

```
Undefined array key "clause"
```

```
Undefined array key "value"
```