### PR TITLE
getRelationshipTitleColumnName to getRelationshipTitleAttribute for Filament v3.

### DIFF
--- a/src/Concerns/HasClauses.php
+++ b/src/Concerns/HasClauses.php
@@ -71,7 +71,7 @@ trait HasClauses
 
         if ($this->queriesRelationships()) {
             return $query->whereHas($this->getRelationshipName(), function ($query) use ($clause, $data) {
-                $this->applyClause($query, $this->getRelationshipTitleColumnName(), $clause, $data);
+                $this->applyClause($query, $this->getRelationshipTitleAttribute(), $clause, $data);
             });
         }
 


### PR DESCRIPTION
To make it compatible with relationships in Filament, the function `getRelationshipTitleColumnName` has been changed to `getRelationshipTitleAttribute`

This was producing the error.

```
Method Webbingbrasil\FilamentAdvancedFilter\Filters\NumberFilter::getRelationshipTitleColumnName does not exist.
```